### PR TITLE
Fix typo in settings

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -141,7 +141,7 @@ function NZBDonkeyOptions() {
 		name: 'categories',
 		type: 'radio',
 		options: [{
-			desc: 'Do not unse categories',
+			desc: 'Do not use categories',
 			value: false
 		}, {
 			desc: 'Use default category',


### PR DESCRIPTION
Corrects the typo "Do not unse categories" -> "Do not use categories"
Fixes Tensai75/NZBDonkey#1