### PR TITLE
feat(interception): add interception of already initiated downloads

### DIFF
--- a/src/components/interception/editDomainDialog.vue
+++ b/src/components/interception/editDomainDialog.vue
@@ -52,7 +52,9 @@ function reset() {
   >
     <Dialog :visible="true" :closable="false" modal :header="title" style="width: 48rem; max-width: 48rem">
       <div class="flex items-center gap-4 mb-4 flex-auto">
-        <label for="name" class="font-semibold w-24">{{ i18n.t('settings.interception.domains.domain.title') }}</label>
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">{{
+          i18n.t('settings.interception.domains.domain.title')
+        }}</label>
         <FormField
           v-slot="$field"
           :name="i18n.t('settings.interception.domains.domain.title')"
@@ -78,7 +80,7 @@ function reset() {
         </FormField>
       </div>
       <div class="flex items-center gap-4 mb-4">
-        <label for="name" class="font-semibold w-24">{{
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">{{
           i18n.t('settings.interception.domains.domain.pathRegExp')
         }}</label>
         <FormField
@@ -106,7 +108,7 @@ function reset() {
         </FormField>
       </div>
       <div class="flex items-center gap-4 pt-4 mb-4">
-        <label for="name" class="font-semibold w-24">{{
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">{{
           i18n.t('settings.interception.domains.domain.showNzbDialog.title')
         }}</label>
         <FormField
@@ -123,7 +125,41 @@ function reset() {
         </FormField>
       </div>
       <div class="flex items-center gap-4 pt-4 mb-4">
-        <label for="name" class="font-semibold w-24">{{
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">
+          {{ i18n.t('settings.interception.domains.domain.doubleCountDownloads') }}
+        </label>
+        <FormField
+          :name="i18n.t('settings.interception.domains.domain.doubleCountDownloads')"
+          :initial-value="domain.allowDownloadInterception"
+          class="grid-row flex-auto"
+        >
+          <div class="flex items-center">
+            <ToggleSwitch v-model="domain.allowDownloadInterception" />
+            <label class="label-text pl-4">
+              {{ i18n.t('settings.interception.domains.domain.allowDoubleCountDownloads') }}
+            </label>
+          </div>
+        </FormField>
+      </div>
+      <div class="flex items-center gap-4 pt-4 mb-4">
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">
+          {{ i18n.t('settings.interception.domains.domain.doubleCountDownloadsWarning') }}
+        </label>
+        <FormField
+          :name="i18n.t('settings.interception.domains.domain.doubleCountDownloadsWarning')"
+          :initial-value="domain.dontShowDoubleCountWarning"
+          class="grid-row flex-auto"
+        >
+          <div class="flex items-center">
+            <ToggleSwitch v-model="domain.dontShowDoubleCountWarning" />
+            <label class="label-text pl-4">
+              {{ i18n.t('settings.interception.domains.domain.ignoreDoubleCountDownloadsWarning') }}
+            </label>
+          </div>
+        </FormField>
+      </div>
+      <div class="flex items-center gap-4 pt-4 mb-4">
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">{{
           i18n.t('settings.interception.domains.domain.requiresPostDataHandling.title')
         }}</label>
         <FormField
@@ -166,7 +202,7 @@ function reset() {
         </FormField>
       </div>
       <div class="flex items-center gap-4 pt-4 mb-4">
-        <label for="name" class="font-semibold w-24">Fetch Origin</label>
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">Fetch Origin</label>
         <FormField name="Fetch Origin" :initial-value="domain.fetchOrigin" class="grid-row flex-auto">
           <div class="flex items-center">
             <div class="flex items-center gap-2">
@@ -193,7 +229,7 @@ function reset() {
         </FormField>
       </div>
       <div class="flex items-center gap-4 pt-4 mb-4">
-        <label for="name" class="font-semibold w-24">{{
+        <label for="name" class="font-semibold min-w-32 max-w-32 w-32">{{
           i18n.t('settings.interception.domains.domain.interceptArchiveFiles.title')
         }}</label>
         <FormField

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,6 +1,6 @@
 import { PublicPath } from 'wxt/browser'
 
-import { defineBackground } from '#imports'
+import { browser, defineBackground } from '#imports'
 import generalBackground from '@/entrypoints/background/general'
 import interceptionBackground from '@/entrypoints/background/interception'
 import settingsUpdate from '@/entrypoints/background/settingsUpdate'

--- a/src/entrypoints/background/interception/downloadInterceptionHanderl.ts
+++ b/src/entrypoints/background/interception/downloadInterceptionHanderl.ts
@@ -1,0 +1,174 @@
+import { fetchInterceptedRequest } from './interceptedRequestsHandler'
+
+import { browser, Browser } from '#imports'
+import * as interception from '@/services/interception'
+import log from '@/services/logger/debugLogger'
+import { onMessage, sendMessage } from '@/services/messengers/extensionMessenger'
+import { InterceptionRequest } from '@/services/messengers/windowMessenger'
+import { getRelativeURL } from '@/utils/fetchUtilities'
+
+// Extend the Window interface to include the custom property
+declare global {
+  interface Window {
+    __NZBDONKEY_DOUBLECOUNTWARNING_SCRIPT_INJECTED__?: boolean
+    __TAB_ID__?: number
+  }
+}
+
+const doubleCountWarningScriptSource: string = '/content-scripts/doublecountwarning.js'
+
+const requestDetailsMap = new Map<string, { formData?: string; tabId?: number; source: string }>()
+
+export default async function (): Promise<void> {
+  addListener()
+  interception.watchSettings(async (settings) => {
+    if (settings.enabled) {
+      removeListener()
+      addListener()
+    } else {
+      removeListener()
+    }
+  })
+  onMessage('doubleCountWarningResponse', async (message) => {
+    log.info('received domain settings from the double count warning script')
+    const settings = await interception.getSettings()
+    const index = settings.domains.findIndex((domain) => domain.domain === message.data.domain.domain)
+    if (index !== -1) {
+      settings.domains[index] = message.data.domain
+      interception.saveSettings(settings)
+    }
+  })
+}
+
+async function addListener(): Promise<void> {
+  log.info('adding download interception listeners')
+  try {
+    browser.webRequest.onBeforeRequest.addListener(webrequestOnBeforeRequestListerner, { urls: ['<all_urls>'] }, [
+      'requestBody',
+    ])
+    browser.downloads.onCreated.addListener(downloadsOnCreatedListener)
+    log.info('download interception listeners added successfully')
+  } catch (e) {
+    log.error('failed to add download interception listeners:', e instanceof Error ? e : new Error(String(e)))
+  }
+}
+
+function removeListener(): void {
+  log.info('removing download interception listeners')
+  try {
+    if (browser.webRequest.onBeforeRequest.hasListener(webrequestOnBeforeRequestListerner)) {
+      browser.webRequest.onBeforeRequest.removeListener(webrequestOnBeforeRequestListerner)
+    }
+    if (browser.downloads.onCreated.hasListener(downloadsOnCreatedListener)) {
+      browser.downloads.onCreated.removeListener(downloadsOnCreatedListener)
+    }
+    log.info('download interception listeners removed sucesssfully')
+  } catch (e) {
+    log.error('failed to remove download interception listeners:', e instanceof Error ? e : new Error(String(e)))
+  }
+}
+
+function webrequestOnBeforeRequestListerner(details: Browser.webRequest.WebRequestBodyDetails): void {
+  interception.getSettings().then(async (settings) => {
+    if (!settings.enabled || !isURLTracked(details.url)) return
+    if (details.method === 'POST' && details.requestBody) {
+      const formData = details.requestBody.formData
+        ? Object.entries(details.requestBody.formData)
+            .map(([key, value]) => `${key}=${value}`)
+            .join('&')
+        : undefined
+      // @ts-expect-error: Property 'originUrl' does not exist on type 'WebRequestBodyDetails'
+      requestDetailsMap.set(details.url, { formData, tabId: details.tabId, source: details.originUrl ?? '' })
+    } else {
+      // @ts-expect-error: Property 'originUrl' does not exist on type 'WebRequestBodyDetails'
+      requestDetailsMap.set(details.url, { tabId: details.tabId, source: details.originUrl ?? '' })
+    }
+  })
+}
+
+function downloadsOnCreatedListener(downloadItem: Browser.downloads.DownloadItem) {
+  interception.getActiveDomains().then(async (activeDomains) => {
+    const finalUrl = import.meta.env.CHROME ? downloadItem.finalUrl : downloadItem.url
+    const currentDomain = activeDomains.find((domain) => finalUrl.includes(domain.domain))
+    const originalRequest = requestDetailsMap.get(finalUrl)
+    if (!currentDomain || finalUrl.match(currentDomain.pathRegExp) === null) return
+    if (!currentDomain.allowDownloadInterception) {
+      log.info(`download interception not allowed for domain ${currentDomain.domain}`)
+      if (!currentDomain.dontShowDoubleCountWarning) {
+        log.info('showing double count warning')
+        showDoubleCountWarning(currentDomain, originalRequest?.tabId ?? -1)
+      }
+      return
+    }
+    log.info(`intercepting download for URL: ${finalUrl}`)
+    try {
+      await browser.downloads.cancel(downloadItem.id)
+    } catch (e) {
+      log.error('failed to cancel download:', e instanceof Error ? e : new Error(String(e)))
+    }
+    if (!currentDomain.dontShowDoubleCountWarning) {
+      log.info('showing double count warning')
+      showDoubleCountWarning(currentDomain, originalRequest?.tabId ?? -1)
+    }
+    const interceptionRequest: InterceptionRequest = {
+      url: finalUrl,
+      source: (originalRequest?.source != '' ? originalRequest?.source : downloadItem.url) as string,
+      domain: new URL(finalUrl).hostname,
+      options: { credentials: 'include' } as RequestInit,
+      formData: originalRequest?.formData ?? '',
+      searchParams: '',
+    }
+    // handle the download request
+    fetchInterceptedRequest(interceptionRequest)
+  })
+}
+
+async function isURLTracked(url: string, domains?: interception.DomainSettings[]): Promise<boolean> {
+  const path = url.startsWith('/') ? url : getRelativeURL(url)
+  for (const { domain, pathRegExp } of domains ?? (await interception.getActiveDomains())) {
+    try {
+      const regex = new RegExp(pathRegExp, 'i') // Convert string to RegExp
+      if (regex.test(path)) {
+        return true // Return true if the URL matches any regex
+      }
+    } catch (e) {
+      log.error(`invalid regex for domain ${domain}: ${pathRegExp}`, e instanceof Error ? e : new Error(String(e)))
+    }
+  }
+  return false // Return false if no match is found
+}
+
+async function showDoubleCountWarning(domain: interception.DomainSettings, tabId: number): Promise<void> {
+  try {
+    // Check if the script is already injected
+    const [result] = await browser.scripting.executeScript({
+      target: { tabId: tabId },
+      func: () => !!window.__NZBDONKEY_DOUBLECOUNTWARNING_SCRIPT_INJECTED__,
+    })
+    // If the script is not injected, inject it
+    if (!result?.result) {
+      // Set a marker to indicate the script is injected
+      await browser.scripting.executeScript({
+        target: { tabId: tabId },
+        func: (tabId) => {
+          window.__NZBDONKEY_DOUBLECOUNTWARNING_SCRIPT_INJECTED__ = true
+          window.__TAB_ID__ = tabId
+        },
+        args: [tabId],
+      })
+      // Inject the script
+      await browser.scripting.executeScript({
+        target: { tabId: tabId },
+        files: [doubleCountWarningScriptSource],
+      })
+      log.info(`double count warning script injected successfully into tab ${tabId}.`)
+      sendMessage('doubleCountWarning', { tabId: tabId, domain }, tabId)
+    } else {
+      sendMessage('doubleCountWarning', { tabId: tabId, domain }, tabId)
+      log.info(`double count warning script already injected into tab ${tabId}.`)
+    }
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error('unknown error')
+    log.error(`error injecting selection script into tab ${tabId}:`, error)
+  }
+}

--- a/src/entrypoints/background/interception/index.ts
+++ b/src/entrypoints/background/interception/index.ts
@@ -1,7 +1,9 @@
 import contentScriptRegistrationHandler from './contentScriptRegistrationHandler'
+import downloadInterceptionHanderl from './downloadInterceptionHanderl'
 import interceptedRequestsHandler from './interceptedRequestsHandler'
 
 export default function (): void {
   contentScriptRegistrationHandler()
   interceptedRequestsHandler()
+  downloadInterceptionHanderl()
 }

--- a/src/entrypoints/background/interception/interceptedRequestsHandler.ts
+++ b/src/entrypoints/background/interception/interceptedRequestsHandler.ts
@@ -24,7 +24,7 @@ export default function (): void {
   })
 }
 
-async function fetchInterceptedRequest({
+export async function fetchInterceptedRequest({
   url,
   options,
   domain,
@@ -32,9 +32,9 @@ async function fetchInterceptedRequest({
   searchParams,
   source,
 }: InterceptionRequest): Promise<void> {
-  // Process formData and searchParams into the request body
-  options.body = processRequestBody(formData, searchParams)
   try {
+    // Process formData and searchParams into the request body
+    options.body = processRequestBody(formData, searchParams)
     const settings = await getInterceptionSettings()
     const setting = settings.domains.find((domainSetting) => domainSetting.domain === domain)
     const response = await useFetch(url, options)

--- a/src/entrypoints/background/settingsUpdate/fromV0_7_7.ts
+++ b/src/entrypoints/background/settingsUpdate/fromV0_7_7.ts
@@ -101,7 +101,6 @@ export default async function (): Promise<void> {
   try {
     const storedSettings = await browser.storage.sync.get(null)
     const oldSettings = storedSettings as OldSettings
-    console.log('loaded settings:', storedSettings)
     await migrateGeneralSettings(oldSettings)
     await migrateTargetSettings(oldSettings)
     await migrateSearchEnginesSettings(oldSettings)

--- a/src/entrypoints/doublecountwarning.content/App.vue
+++ b/src/entrypoints/doublecountwarning.content/App.vue
@@ -1,0 +1,142 @@
+<script lang="ts" setup>
+import { FormField } from '@primevue/forms'
+import { Button, Dialog, ToggleSwitch } from 'primevue'
+import { nextTick, onMounted, ref, toRaw } from 'vue'
+import { PublicPath } from 'wxt/browser'
+
+import { i18n } from '#i18n'
+import { browser } from '#imports'
+import NZBDonkeyLogo from '@/components/nzbdonkeyLogo.vue'
+import { DomainSettings } from '@/services/interception'
+import log from '@/services/logger/debugLogger'
+import { onMessage, sendMessage } from '@/services/messengers/extensionMessenger'
+
+log.info('analyseSelection script successfully loaded')
+const domain = ref<DomainSettings>({} as DomainSettings)
+const domainSettings = ref<DomainSettings>({} as DomainSettings)
+const visible = ref(true)
+
+function submit() {
+  close()
+  sendMessage('doubleCountWarningResponse', {
+    domain: toRaw(domain.value),
+  })
+}
+
+onMessage('doubleCountWarning', (message) => {
+  if (message.data.tabId === window.__TAB_ID__) {
+    if (message.data.domain) {
+      domain.value = JSON.parse(JSON.stringify(message.data.domain)) as DomainSettings
+      domainSettings.value = message.data.domain
+    }
+    visible.value = true
+  }
+})
+
+// fix for tailwind rem based sizeing
+const html = document.querySelector('html')
+const fontSize = html ? html.style.fontSize : ''
+if (html) html.style.fontSize = '16px'
+
+const shadowRoot = document.querySelector('nzbdonkey-doublecountwarning-dialog') as HTMLElement
+const shadowRootHead = shadowRoot.shadowRoot?.querySelector('head') as HTMLElement
+const shadowRootBody = shadowRoot.shadowRoot?.querySelector('body') as HTMLElement
+onMounted(async () => {
+  await nextTick()
+  loadStyles()
+  movePrimeVueStyles()
+})
+
+function loadStyles() {
+  // load styles
+  const url = browser.runtime.getURL('/assets/style.css' as PublicPath)
+  const link = document.createElement('link')
+  link.href = url
+  link.type = 'text/css'
+  link.rel = 'stylesheet'
+  shadowRootHead.append(link)
+}
+
+function movePrimeVueStyles() {
+  // fix for primevue mounting styles in document head instead in shadow dom head
+  const primeStyles = document.querySelectorAll('head > style[type="text/css"][data-primevue-style-id]')
+  primeStyles.forEach((node) => {
+    if (
+      !node.getAttribute('data-primevue-style-id')?.includes('variables') ||
+      node.getAttribute('data-primevue-style-id')?.includes('global')
+    ) {
+      const clonedNode = node.cloneNode(true) as HTMLStyleElement
+      shadowRootHead.append(clonedNode)
+      node.remove()
+    }
+  })
+}
+
+function close() {
+  visible.value = false
+  if (html) html.style.removeProperty('font-size')
+  if (html && fontSize != '') html.style.fontSize = fontSize
+}
+</script>
+
+<template>
+  <Dialog
+    v-model:visible="visible"
+    :closable="false"
+    modal
+    :append-to="shadowRootBody"
+    header="NZBDonkey"
+    style="width: 48rem; max-width: 48rem; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif"
+  >
+    <template #header>
+      <div class="inline-flex items-center justify-center gap-2">
+        <NZBDonkeyLogo size="32" color="#FFA726" />
+        <span class="font-bold whitespace-nowrap text-2xl">{{ i18n.t('common.caution') }}</span>
+      </div>
+    </template>
+    <div class="gap-4 mb-4">
+      <div v-if="!domainSettings.allowDownloadInterception" class="mb-8">
+        <h2>
+          {{ i18n.t('interception.doubleCountDownloadInformation', [domain.domain]) }}
+        </h2>
+      </div>
+      <div v-if="domainSettings.allowDownloadInterception" class="mb-8">
+        <h2>
+          {{ i18n.t('interception.doubleCountDownloadWarning', [domain.domain]) }}
+        </h2>
+      </div>
+      <FormField
+        name="Doppelt zählende Downloads"
+        :initial-value="domain.allowDownloadInterception"
+        class="grid-row mb-4"
+      >
+        <div class="flex items-center">
+          <ToggleSwitch v-model="domain.allowDownloadInterception" />
+          <label class="label-text pl-4">
+            {{ i18n.t('settings.interception.domains.domain.allowDoubleCountDownloads') }}
+          </label>
+        </div>
+      </FormField>
+      <FormField
+        name="Warnung zu doppelt zählenden Downloads"
+        :initial-value="domain.dontShowDoubleCountWarning"
+        class="grid-row"
+      >
+        <div class="flex items-center">
+          <ToggleSwitch v-model="domain.dontShowDoubleCountWarning" />
+          <label class="label-text pl-4">
+            {{ i18n.t('settings.interception.domains.domain.ignoreDoubleCountDownloadsWarning') }}
+          </label>
+        </div>
+      </FormField>
+    </div>
+    <template #footer>
+      <div class="flex justify-between w-full gap-4 testClass">
+        <div></div>
+        <div class="flex justify-end gap-4">
+          <Button type="button" :label="i18n.t('common.ok')" @click="submit()"></Button>
+        </div>
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/src/entrypoints/doublecountwarning.content/index.ts
+++ b/src/entrypoints/doublecountwarning.content/index.ts
@@ -1,0 +1,45 @@
+import PrimeVue from 'primevue/config'
+import { createApp } from 'vue'
+
+import App from './App.vue'
+
+import { createShadowRootUi, defineContentScript } from '#imports'
+import { MyPreset } from '@/assets/presets'
+import log from '@/services/logger/debugLogger'
+
+export default defineContentScript({
+  registration: 'runtime',
+  matches: ['<all_urls>'],
+  main(ctx) {
+    log.initDebugLog('doublecountwarning-content')
+    const primeVueTheme = {
+      theme: {
+        preset: MyPreset,
+        options: {
+          prefix: 'nzbdonkey',
+        },
+      },
+    }
+    // Define the UI
+    createShadowRootUi(ctx, {
+      name: 'nzbdonkey-doublecountwarning-dialog',
+      position: 'inline',
+      anchor: 'body',
+      append: 'last',
+      inheritStyles: true,
+      onMount: (container) => {
+        // Define how the UI will be mounted inside the container
+        const app = createApp(App).use(PrimeVue, primeVueTheme)
+        app.mount(container)
+        return app
+      },
+      onRemove: (app) => {
+        // Unmount the app when the UI is removed
+        app?.unmount()
+      },
+    }).then((ui) => {
+      // Mount the UI
+      ui.mount()
+    })
+  },
+})

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -215,7 +215,11 @@
             "title": "NZB-Einstellungsdialog",
             "description": "einen Dialog anzeigen um Titel, Passwort und andere Einstellungen anzupassen"
           },
-          "pathRegExp": "RegExp für den Download-Pfad"
+          "pathRegExp": "RegExp für den Download-Pfad",
+          "doubleCountDownloads": "Doppelt zählende Downloads",
+          "allowDoubleCountDownloads": "das Abfangen von Downloads erlauben, die auf Seiten mit einem Download-Zähler möglicherweise doppelt gezählt werden",
+          "doubleCountDownloadsWarning": "Warnung vor doppelt gezählten Downloads",
+          "ignoreDoubleCountDownloadsWarning": "die Warnung vor doppelt gezählten Downloads nicht mehr anzeigen"
         },
         "domainsList": "Vordefinierte Domänen",
         "addNewDomain": "neue Domäne hinzufügen",
@@ -315,7 +319,9 @@
     "fetchError": "NZB Download-Überwachung: Fehler beim laden von $1: $2",
     "fetchSuccess": "NZB Donwload-Überwachung: Datei  \"$1\" erfolgreich geladen von $2",
     "fetchResponseProcessingError": "Fehler bei der Bearbeitung der Datei \"$1\", abgefangen von $2: $3",
-    "success": "NZB-Datei \"$1\" wurde erfolgreich abgefangen"
+    "success": "NZB-Datei \"$1\" wurde erfolgreich abgefangen",
+    "doubleCountDownloadInformation": "Dieser Download von $1 hätte von NZBDonkey abgefangen werden können. Wenn $1 jedoch einen Download-Zähler hat, könnte es sein, dass dieser Download dann doppelt gezählt wird.",
+    "doubleCountDownloadWarning": "Falls $1 einen Download-Zähler hat, wird dieser Download möglicherweise doppelt gezählt."
   },
   "targets": {
     "download": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -215,7 +215,11 @@
             "title": "NZB settings dialog",
             "description": "show a dialog to set titel, password, and other options"
           },
-          "pathRegExp": "RegExp for the download path"
+          "pathRegExp": "RegExp for the download path",
+          "doubleCountDownloads": "Double-counting downloads",
+          "allowDoubleCountDownloads": "allow the interception of downloads that may be counted twice on pages with a download counter",
+          "doubleCountDownloadsWarning": "Warning for double counting downloads",
+          "ignoreDoubleCountDownloadsWarning": "no longer display the warning for double-counting downloads"
         },
         "domainsList": "Predefined domains",
         "addNewDomain": "add new domain",
@@ -315,7 +319,9 @@
     "fetchError": "NZB download interception: error loading from url $1: $2",
     "fetchSuccess": "NZB download interception: file \"$1\" successfully loaded from $2",
     "fetchResponseProcessingError": "error while processing file \"$1\" intercepted from $2: $3",
-    "success": "NZB file \"$1\" was intercepted successfully"
+    "success": "NZB file \"$1\" was intercepted successfully",
+    "doubleCountDownloadInformation": "This download of $1 could have been intercepted by NZBDonkey. However, if $1 has a download counter, it could be that this download is then counted twice.",
+    "doubleCountDownloadWarning": "If $1 has a download counter, this download may be counted twice."
   },
   "targets": {
     "download": {

--- a/src/services/interception/functions.ts
+++ b/src/services/interception/functions.ts
@@ -1,6 +1,7 @@
 import { PublicPath } from 'wxt/browser'
 
 import { ArchiveReader, libarchiveWasm } from './libarchive-wasm'
+import { DomainSettings, get as getSettings } from './settings'
 
 import log from '@/services/logger/debugLogger'
 import { NZBFileObject } from '@/services/nzbfile'
@@ -31,4 +32,9 @@ export async function extractArchive(blob: Blob, source: string): Promise<NZBFil
   }
   reader.free()
   return nzbFiles
+}
+
+export async function getActiveDomains(): Promise<DomainSettings[]> {
+  const settings = await getSettings()
+  return settings.domains.filter((domain) => domain.isActive)
 }

--- a/src/services/interception/settings.ts
+++ b/src/services/interception/settings.ts
@@ -22,6 +22,8 @@ export const defaultDomainSettings: DomainSettings = {
   postDataHandling: 'sendAsFormData',
   fetchOrigin: 'background',
   archiveFileExtensions: [],
+  allowDownloadInterception: false,
+  dontShowDoubleCountWarning: false,
 }
 
 export type DomainSettings = {
@@ -34,6 +36,8 @@ export type DomainSettings = {
   postDataHandling: 'sendAsFormData' | 'sendAsURLSearchParams'
   fetchOrigin: 'injection' | 'background'
   archiveFileExtensions: string[]
+  allowDownloadInterception?: boolean
+  dontShowDoubleCountWarning?: boolean
   icon?: string
 }
 

--- a/src/services/messengers/extensionMessenger.ts
+++ b/src/services/messengers/extensionMessenger.ts
@@ -1,6 +1,7 @@
 import { defineExtensionMessaging, RemoveListenerCallback as RemoveListenerCallbackType } from '@webext-core/messaging'
 
 import { Settings as GeneralSettings } from '@/services/general'
+import { DomainSettings } from '@/services/interception'
 import {
   InterceptionRequest,
   InterceptionRequestFetchError,
@@ -16,6 +17,8 @@ interface ProtocolMap {
   getGeneralSettings(data: boolean): Promise<GeneralSettings>
   searchNzbFile(data: { nzblnk: string; source: string }): void
   nzbFileDialog(data: { windowID: number }): NZBFileObject | NZBFileObject[]
+  doubleCountWarning(data: { tabId: number; domain: DomainSettings }): void
+  doubleCountWarningResponse(data: { domain: DomainSettings }): void
 }
 export const { sendMessage, onMessage } = defineExtensionMessaging<ProtocolMap>()
 export type RemoveListenerCallback = RemoveListenerCallbackType

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -11,7 +11,7 @@ const getManifest: (env: ConfigEnv) => Partial<Browser.runtime.Manifest> = (env)
     name: '__MSG_extension_name__',
     description: '__MSG_extension_description__',
     default_locale: 'en',
-    permissions: ['storage', 'scripting', 'notifications', 'downloads', 'contextMenus', 'clipboardWrite'],
+    permissions: ['storage', 'scripting', 'notifications', 'downloads', 'contextMenus', 'clipboardWrite', 'webRequest'],
     host_permissions: ['<all_urls>'],
     web_accessible_resources: [
       {


### PR DESCRIPTION
As this can lead to downloads on pages with a download counter being counted twice, a warning is displayed and the function must be activated manually