### PR TITLE
chore: use psl for base domain resolution

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,2 +1,9 @@
 // global.d.ts
 /// <reference types="vite-plugin-md-to-html/types" />
+
+// Type definitions for the 'psl' module
+declare module 'psl' {
+  export function parse(domain: string): { input: string; tld: string; sld: string; domain: string; subdomain: string }
+  export function isValid(domain: string): boolean
+  export function get(domain: string): string | null
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "linkedom": "^0.18.11",
         "primeicons": "^7.0.0",
         "primevue": "^4.2.5",
+        "psl": "^1.15.0",
         "tailwindcss-primeui": "^0.4.0",
         "vue": "^3.5.12"
       },
@@ -8452,6 +8453,18 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "devOptional": true
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/publish-browser-extension": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/publish-browser-extension/-/publish-browser-extension-3.0.2.tgz",
@@ -8637,7 +8650,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "linkedom": "^0.18.11",
     "primeicons": "^7.0.0",
     "primevue": "^4.2.5",
+    "psl": "^1.15.0",
     "tailwindcss-primeui": "^0.4.0",
     "vue": "^3.5.12"
   },

--- a/src/entrypoints/background/interception/declarativeNetRequestHandler.ts
+++ b/src/entrypoints/background/interception/declarativeNetRequestHandler.ts
@@ -9,7 +9,7 @@ import notifications from '@/services/notifications'
 import {
   DeserializedResponse,
   deserializeResponse,
-  getBaseDomainFromULR,
+  getBaseDomainFromURL,
   serializeRequest,
 } from '@/utils/fetchUtilities'
 
@@ -115,7 +115,7 @@ function onErrorOccurredListener(details: Browser.webRequest.WebRequestDetails):
       if (!cachedRequest) throw new Error(`no cached request found for requestId ${details.requestId}`)
       requestCache.delete(details.requestId) // Clear the cache after processing
       const { url, source } = cachedRequest
-      const domain = getBaseDomainFromULR(url)
+      const domain = getBaseDomainFromURL(url)
       const setting = (await interception.getSettings()).domains.find((d) => d.domain === domain)
       if (!setting) throw new Error(`no domain setting found for ${domain}`)
       try {

--- a/src/entrypoints/background/interception/interceptedRequestsHandler.ts
+++ b/src/entrypoints/background/interception/interceptedRequestsHandler.ts
@@ -11,7 +11,7 @@ import notifications from '@/services/notifications'
 import { NZBFileObject } from '@/services/nzbfile'
 import {
   DeserializedResponse,
-  getBaseDomainFromULR,
+  getBaseDomainFromURL,
   getFilenameFromResponse,
   getHttpStatusText,
 } from '@/utils/fetchUtilities'
@@ -46,7 +46,7 @@ export async function processInterceptedRequestResponse({
 }): Promise<void> {
   let nzbFiles: NZBFileObject[] = [] // Initialize nzbFiles here
   const url = response.url
-  const domain = getBaseDomainFromULR(url)
+  const domain = getBaseDomainFromURL(url)
   const filename = getFilenameFromResponse(response as Response)
   const setting = (await getInterceptionSettings()).domains.find((d) => d.domain === domain)
   try {

--- a/src/services/resolvers.ts
+++ b/src/services/resolvers.ts
@@ -1,4 +1,5 @@
 import { FormFieldResolverOptions } from '@primevue/forms'
+import psl from 'psl'
 
 import { i18n } from '#i18n'
 import { browser } from '#imports'
@@ -52,8 +53,7 @@ export const requiredBaseDomainResolver = ({ value, name = '' }: FormFieldResolv
       message: i18n.t('validation.isRequired', [name]),
     })
   }
-  const regex = /^[a-zA-Z0-9-]{1,63}(?:\.(?:(?:a[cd]|com?|edu|gov|net|org?)\.[a-zA-Z0-9-]{2}|[a-zA-Z]{2,63}))?$/i
-  if (!regex.test(value)) {
+  if (psl.get(value) !== value) {
     errors.push({ message: i18n.t('validation.noBaseDomain') })
   }
   return { errors }

--- a/src/utils/fetchUtilities.ts
+++ b/src/utils/fetchUtilities.ts
@@ -1,5 +1,6 @@
-import { b64EncodeUnicode, getFileNameFromPath } from '@/utils/stringUtilities'
 import psl from 'psl'
+
+import { b64EncodeUnicode, getFileNameFromPath } from '@/utils/stringUtilities'
 
 const DEFAULT_HEADER = { 'X-NZBDonkey': 'true' }
 const DEFAULT_TIMEOUT = 30000
@@ -218,12 +219,12 @@ export const getFilenameFromResponse = (response: Response): string => {
 export const getBaseDomainFromULR = (url: string): string => {
   const hostname = new URL(url).hostname
   const domain = psl.get(hostname)
-  
+
   // Fall back to simple extraction for edge cases
   if (domain === null) {
     return hostname.split('.').slice(-2).join('.')
   }
-  
+
   return domain
 }
 

--- a/src/utils/fetchUtilities.ts
+++ b/src/utils/fetchUtilities.ts
@@ -1,4 +1,5 @@
 import { b64EncodeUnicode, getFileNameFromPath } from '@/utils/stringUtilities'
+import psl from 'psl'
 
 const DEFAULT_HEADER = { 'X-NZBDonkey': 'true' }
 const DEFAULT_TIMEOUT = 30000
@@ -215,7 +216,15 @@ export const getFilenameFromResponse = (response: Response): string => {
  * @throws {Error} Throws an error if the URL is invalid.
  */
 export const getBaseDomainFromULR = (url: string): string => {
-  return new URL(url).hostname.split('.').slice(-2).join('.')
+  const hostname = new URL(url).hostname
+  const domain = psl.get(hostname)
+  
+  // Fall back to simple extraction for edge cases
+  if (domain === null) {
+    return hostname.split('.').slice(-2).join('.')
+  }
+  
+  return domain
 }
 
 /**

--- a/src/utils/fetchUtilities.ts
+++ b/src/utils/fetchUtilities.ts
@@ -216,7 +216,7 @@ export const getFilenameFromResponse = (response: Response): string => {
  * @return {string} The base domain.
  * @throws {Error} Throws an error if the URL is invalid.
  */
-export const getBaseDomainFromULR = (url: string): string => {
+export const getBaseDomainFromURL = (url: string): string => {
   const hostname = new URL(url).hostname
   const domain = psl.get(hostname)
 


### PR DESCRIPTION
Uses [psl](https://www.npmjs.com/package/psl) (domain name parser based on the [Public Suffix List](https://publicsuffix.org/)) for base domain resolution.

This enables support for indexers which use ccTLDs, for example:
* https://althub.co.za/
* https://ninjacentral.co.za/