### PR TITLE
fix: torbox api path typo

### DIFF
--- a/src/services/targets/torbox/functions.ts
+++ b/src/services/targets/torbox/functions.ts
@@ -24,7 +24,7 @@ export const push = async (nzb: NZBFileObject, targetSettings: TargetSettings): 
     log.info(`pushing file "${nzb.title}" to ${targetSettings.name}`)
     try {
       const options = setOptions(settings)
-      options.path = 'usenet/asyncccreateusenetdownload'
+      options.path = 'usenet/asynccreateusenetdownload'
       options.data = new FormData()
       options.data.append(
         'file',


### PR DESCRIPTION
Pushing to torbox currently ends on 404 due to a typo in api path.