### PR TITLE
feat: add custom HTTP headers support for NZB file targets

### DIFF
--- a/src/components/inputs/customHeadersInput.vue
+++ b/src/components/inputs/customHeadersInput.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { Button, InputText, Message } from 'primevue'
+import { i18n } from '#i18n'
+
+const headers = defineModel<Array<{ name: string; value: string }>>({ default: () => [] })
+
+const addHeader = () => headers.value.push({ name: '', value: '' })
+const removeHeader = (index: number) => headers.value.splice(index, 1)
+
+const isDuplicate = (index: number) =>
+  headers.value.some((h, i) => i !== index && h.name.trim() !== '' && h.name.trim() === headers.value[index].name.trim())
+</script>
+
+<template>
+  <div v-if="headers.length === 0" class="text-sm mb-2">
+    {{ i18n.t('common.settings.customHeaders.empty') }}
+  </div>
+  <div v-for="(header, index) in headers" :key="index" class="mb-2">
+    <div class="flex items-center gap-2">
+      <InputText
+        v-model="header.name"
+        :placeholder="i18n.t('common.settings.customHeaders.name')"
+        size="small"
+        class="flex-1"
+        autocomplete="off"
+        type="text"
+      />
+      <InputText
+        v-model="header.value"
+        :placeholder="i18n.t('common.settings.customHeaders.value')"
+        size="small"
+        class="flex-1"
+        autocomplete="off"
+        type="text"
+      />
+      <Button icon="pi pi-trash" severity="danger" variant="text" size="small" @click="removeHeader(index)" />
+    </div>
+    <Message v-if="isDuplicate(index)" severity="warn" size="small" variant="simple">
+      {{ i18n.t('common.settings.customHeaders.duplicateWarning') }}
+    </Message>
+  </div>
+  <Button
+    icon="pi pi-plus"
+    :label="i18n.t('common.settings.customHeaders.add')"
+    size="small"
+    severity="secondary"
+    @click="addHeader"
+  />
+</template>

--- a/src/components/targets/nzbgetSettings.vue
+++ b/src/components/targets/nzbgetSettings.vue
@@ -4,6 +4,7 @@ import { InputText, Message, RadioButton, Select, ToggleSwitch } from 'primevue'
 import { Ref, computed, watch } from 'vue'
 
 import { i18n } from '#i18n'
+import CustomHeadersInput from '@/components/inputs/customHeadersInput.vue'
 import TimeoutInput from '@/components/inputs/timeoutInput.vue'
 import TestConnectionDialog from '@/components/targets/targetTestConnectionDialog.vue'
 import {
@@ -207,6 +208,14 @@ watch(
         $field.error?.message
       }}</Message>
     </FormField>
+  </div>
+  <div v-if="showAdvancedSettings" class="flex items-start gap-4 mb-4 flex-auto">
+    <label class="font-semibold w-24 text-right pt-2">
+      {{ i18n.t('common.settings.customHeaders.title') }}
+    </label>
+    <div class="flex-auto">
+      <CustomHeadersInput v-model="targetSettings.settings.customHeaders" />
+    </div>
   </div>
   <div class="flex items-center gap-4 mb-4">
     <label for="name" class="font-semibold w-24 text-right">{{ i18n.t('common.settings.timeout.title') }}</label>

--- a/src/components/targets/sabnzbdSettings.vue
+++ b/src/components/targets/sabnzbdSettings.vue
@@ -4,6 +4,7 @@ import { InputText, Message, Select, ToggleSwitch } from 'primevue'
 import { Ref, computed, watch } from 'vue'
 
 import { i18n } from '#i18n'
+import CustomHeadersInput from '@/components/inputs/customHeadersInput.vue'
 import TimeoutInput from '@/components/inputs/timeoutInput.vue'
 import TestConnectionDialog from '@/components/targets/targetTestConnectionDialog.vue'
 import {
@@ -238,6 +239,14 @@ watch(
         $field.error?.message
       }}</Message>
     </FormField>
+  </div>
+  <div v-if="showAdvancedSettings" class="flex items-start gap-4 mb-4 flex-auto">
+    <label class="font-semibold w-24 text-right pt-2">
+      {{ i18n.t('common.settings.customHeaders.title') }}
+    </label>
+    <div class="flex-auto">
+      <CustomHeadersInput v-model="targetSettings.settings.customHeaders" />
+    </div>
   </div>
   <div class="flex items-center gap-4 mb-4">
     <label for="name" class="font-semibold w-24 text-right">{{ i18n.t('common.settings.timeout.title') }}</label>

--- a/src/components/targets/synologySettings.vue
+++ b/src/components/targets/synologySettings.vue
@@ -4,6 +4,7 @@ import { InputText, Message, Select } from 'primevue'
 import { Ref, computed, watch } from 'vue'
 
 import { i18n } from '#i18n'
+import CustomHeadersInput from '@/components/inputs/customHeadersInput.vue'
 import TimeoutInput from '@/components/inputs/timeoutInput.vue'
 import TestConnectionDialog from '@/components/targets/targetTestConnectionDialog.vue'
 import {
@@ -216,6 +217,14 @@ watch(
         $field.error?.message
       }}</Message>
     </FormField>
+  </div>
+  <div v-if="showAdvancedSettings" class="flex items-start gap-4 mb-4 flex-auto">
+    <label class="font-semibold w-24 text-right pt-2">
+      {{ i18n.t('common.settings.customHeaders.title') }}
+    </label>
+    <div class="flex-auto">
+      <CustomHeadersInput v-model="targetSettings.settings.customHeaders" />
+    </div>
   </div>
   <div class="flex items-center gap-4 mb-4">
     <label for="name" class="font-semibold w-24 text-right">{{ i18n.t('common.settings.timeout.title') }}</label>

--- a/src/entrypoints/background/settingsUpdate/index.ts
+++ b/src/entrypoints/background/settingsUpdate/index.ts
@@ -9,6 +9,7 @@ const versionUpdates: Record<string, () => Promise<void>> = {
   '1.3.0': async () => await import('./v1_3_0').then((mod) => mod.default()),
   '1.4.0': async () => await import('./v1_4_0').then((mod) => mod.default()),
   '1.4.3': async () => await import('./v1_4_3').then((mod) => mod.default()),
+  '1.6.0': async () => await import('./v1_6_0').then((mod) => mod.default()),
   // Add future updates here
 }
 

--- a/src/entrypoints/background/settingsUpdate/v1_6_0.ts
+++ b/src/entrypoints/background/settingsUpdate/v1_6_0.ts
@@ -1,0 +1,26 @@
+import { getSettings as getTargetSettings, saveSettings as saveTargetSettings } from '@/services/targets'
+import { Settings as NzbgetTargetSettings } from '@/services/targets/nzbget/settings'
+import { Settings as SabnzbdTargetSettings } from '@/services/targets/sabnzbd/settings'
+import { Settings as SynologyTargetSettings } from '@/services/targets/synology/settings'
+
+export default async function (): Promise<void> {
+  await migrateTargetSettings()
+}
+
+async function migrateTargetSettings() {
+  const settings = await getTargetSettings()
+
+  // Add customHeaders array if it doesn't exist for sabnzbd, nzbget and synology targets
+  settings.targets.forEach((target) => {
+    if (['sabnzbd', 'nzbget', 'synology'].includes(target.type)) {
+      if (
+        (target.settings as SabnzbdTargetSettings | NzbgetTargetSettings | SynologyTargetSettings).customHeaders ===
+        undefined
+      ) {
+        ;(target.settings as SabnzbdTargetSettings | NzbgetTargetSettings | SynologyTargetSettings).customHeaders = []
+      }
+    }
+  })
+
+  await saveTargetSettings(settings)
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -294,7 +294,17 @@
         "seconds": "Sekunden"
       },
       "deviceDescription": "Kann erst nach dem Verbindungstest ausgewählt werden.",
-      "deviceError": "Es sind keine Ziel-Geräte vorhanden!"
+      "deviceError": "Es sind keine Ziel-Geräte vorhanden!",
+      "customHeaders": {
+        "title": "Benutzerdefinierte Header",
+        "description": "Benutzerdefinierte HTTP-Header zu allen API-Anfragen an dieses Ziel hinzufügen",
+        "name": "Header-Name",
+        "value": "Header-Wert",
+        "add": "Header hinzufügen",
+        "remove": "Header entfernen",
+        "empty": "Keine benutzerdefinierten Header definiert",
+        "duplicateWarning": "Doppelter Header-Name"
+      }
     },
     "ok": "OK",
     "next": "Weiter",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -294,7 +294,17 @@
         "seconds": "seconds"
       },
       "deviceDescription": "Can only be selected after the connection test.",
-      "deviceError": "There are no target devices available!"
+      "deviceError": "There are no target devices available!",
+      "customHeaders": {
+        "title": "Custom headers",
+        "description": "Add custom HTTP request headers to every API call made to this target",
+        "name": "Header name",
+        "value": "Header value",
+        "add": "Add header",
+        "remove": "Remove header",
+        "empty": "No custom headers defined",
+        "duplicateWarning": "Duplicate header name"
+      }
     },
     "ok": "OK",
     "next": "Next",

--- a/src/services/targets/nzbget/functions.ts
+++ b/src/services/targets/nzbget/functions.ts
@@ -136,6 +136,13 @@ const setOptions = (settings: Settings): FetchOptions => {
     const basepathMatch = settings.basepath.match(/^\/*(.*?)\/*$/)
     options.basepath = basepathMatch ? basepathMatch[1] + '/' : ''
   }
+  if (settings.customHeaders?.length) {
+    options.headers = Object.fromEntries(
+      settings.customHeaders
+        .filter((h) => h.name.trim() !== '')
+        .map((h) => [h.name.trim(), h.value])
+    )
+  }
   return options
 }
 

--- a/src/services/targets/nzbget/settings.ts
+++ b/src/services/targets/nzbget/settings.ts
@@ -16,6 +16,7 @@ export const defaultSettings: TargetSettings = {
     scheme: 'http',
     username: '',
     timeout: 30000,
+    customHeaders: [],
   },
   categories: categoriesDefaultSettings,
 }
@@ -30,4 +31,5 @@ export type Settings = {
   scheme: 'http' | 'https'
   username: string
   timeout: number
+  customHeaders: Array<{ name: string; value: string }>
 }

--- a/src/services/targets/sabnzbd/functions.ts
+++ b/src/services/targets/sabnzbd/functions.ts
@@ -138,6 +138,13 @@ const setOptions = (settings: Settings): FetchOptions => {
     const basepathMatch = settings.basepath.match(/^\/*(.*?)\/*$/)
     options.basepath = basepathMatch ? basepathMatch[1] + '/' : ''
   }
+  if (settings.customHeaders?.length) {
+    options.headers = Object.fromEntries(
+      settings.customHeaders
+        .filter((h) => h.name.trim() !== '')
+        .map((h) => [h.name.trim(), h.value])
+    )
+  }
   return options
 }
 

--- a/src/services/targets/sabnzbd/settings.ts
+++ b/src/services/targets/sabnzbd/settings.ts
@@ -16,6 +16,7 @@ export const defaultSettings: TargetSettings = {
     port: '8080',
     scheme: 'http',
     timeout: 30000,
+    customHeaders: [],
   },
   categories: categoriesDefaultSettings,
 }
@@ -30,4 +31,5 @@ export type Settings = {
   port: string
   scheme: 'http' | 'https'
   timeout: number
+  customHeaders: Array<{ name: string; value: string }>
 }

--- a/src/services/targets/synology/functions.ts
+++ b/src/services/targets/synology/functions.ts
@@ -146,6 +146,13 @@ const setOptions = (settings: Settings, path: string = ''): FetchOptions => {
     path: path !== '' ? path : 'query.cgi',
     timeout: settings.timeout,
   }
+  if (settings.customHeaders?.length) {
+    options.headers = Object.fromEntries(
+      settings.customHeaders
+        .filter((h) => h.name.trim() !== '')
+        .map((h) => [h.name.trim(), h.value])
+    )
+  }
   return options
 }
 

--- a/src/services/targets/synology/settings.ts
+++ b/src/services/targets/synology/settings.ts
@@ -14,6 +14,7 @@ export const defaultSettings: TargetSettings = {
     scheme: 'http',
     username: '',
     timeout: 30000,
+    customHeaders: [],
   },
   categories: categoriesDefaultSettings,
 }
@@ -26,4 +27,5 @@ export type Settings = {
   scheme: 'http' | 'https'
   username: string
   timeout: number
+  customHeaders: Array<{ name: string; value: string }>
 }


### PR DESCRIPTION
- Add customHeaders field to SABnzbd, NZBGet, and Synology target settings
- Create CustomHeadersInput component for managing header key-value pairs
- Inject custom headers into API requests via setOptions functions
- Add i18n strings for English and German
- Support for any custom headers (e.g., CF-Access-Client-Id/Secret for Cloudflare Tunnels)


<img width="894" height="658" alt="image" src="https://github.com/user-attachments/assets/e7dfc515-43f9-4f48-99b0-c0384b834c9d" />

Would close feature request: https://github.com/Tensai75/NZBDonkey/issues/121

_Note: This did have a good deal of vibe-coding by Claude._